### PR TITLE
Check that targetWindow has postMessage property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function Postis(options) {
     send: function (opts) {
       var method = opts.method;
 
-      if (ready || opts.method === readyMethod && (targetWindow && typeof targetWindow.postMessage !== "undefined")) {
+      if ((ready || opts.method === readyMethod) && (targetWindow && typeof targetWindow.postMessage === "function")) {
         targetWindow.postMessage(JSON.stringify({
           postis: true,
           scope: scope,

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function Postis(options) {
     send: function (opts) {
       var method = opts.method;
 
-      if (ready || opts.method === readyMethod) {
+      if (ready || opts.method === readyMethod && (targetWindow && typeof targetWindow.postMessage !== "undefined")) {
         targetWindow.postMessage(JSON.stringify({
           postis: true,
           scope: scope,


### PR DESCRIPTION
Postis is throwing exceptions occasionally when `targetWindow` has been removed from the DOM.

As a future feature we should add a possibility to destroy the channel safely in case you don't need it anymore.